### PR TITLE
Added encodingPolicies Map to make text encoding configurable

### DIFF
--- a/src/main/java/org/owasp/html/Encoding.java
+++ b/src/main/java/org/owasp/html/Encoding.java
@@ -29,6 +29,7 @@
 package org.owasp.html;
 
 import java.io.IOException;
+import java.util.Map;
 
 import javax.annotation.Nullable;
 
@@ -153,27 +154,46 @@ final class Encoding {
 
   static void encodeHtmlAttribOnto(String plainText, Appendable output)
       throws IOException {
-    encodeHtmlOnto(plainText, output, "{\u200B");
+    encodeHtmlOnto(plainText, output, "{\u200B", null);
   }
 
+  static void encodeHtmlAttribOnto(String plainText, Appendable output, Map<Character, String> encodingPolicies)
+      throws IOException {
+    encodeHtmlOnto(plainText, output, "{\u200B", encodingPolicies);
+  }
+
+  /*
+   * Avoid problems with client-side template languages like
+   * Angular & Polymer which attach special significance to text like
+   * {{...}}.
+   * We split brackets so that these template languages don't end up
+   * executing expressions in sanitized text.
+   */
   static void encodePcdataOnto(String plainText, Appendable output)
       throws IOException {
-    // Avoid problems with client-side template languages like
-    // Angular & Polymer which attach special significance to text like
-    // {{...}}.
-    // We split brackets so that these template languages don't end up
-    // executing expressions in sanitized text.
-    encodeHtmlOnto(plainText, output, "{<!-- -->");
+    encodeHtmlOnto(plainText, output, "{<!-- -->", null);
   }
 
+  static void encodePcdataOnto(String plainText, Appendable output, Map<Character, String> encodingPolicies)
+      throws IOException {
+    encodeHtmlOnto(plainText, output, "{<!-- -->", encodingPolicies);
+  }
+
+  /*
+   * Avoid problems with client-side template languages like
+   * Angular & Polymer which attach special significance to text like
+   * {{...}}.
+   * We split brackets so that these template languages don't end up
+   * executing expressions in sanitized text.
+   */
   static void encodeRcdataOnto(String plainText, Appendable output)
       throws IOException {
-    // Avoid problems with client-side template languages like
-    // Angular & Polymer which attach special significance to text like
-    // {{...}}.
-    // We split brackets so that these template languages don't end up
-    // executing expressions in sanitized text.
-    encodeHtmlOnto(plainText, output, "{\u200B");
+    encodeHtmlOnto(plainText, output, "{\u200B", null);
+  }
+
+  static void encodeRcdataOnto(String plainText, Appendable output, Map<Character, String> encodingPolicies)
+      throws IOException {
+    encodeHtmlOnto(plainText, output, "{\u200B", encodingPolicies);
   }
 
   /**
@@ -183,10 +203,12 @@ final class Encoding {
    * smaller appends.
    * Elides code-units that are not valid XML Characters.
    * @see <a href="http://www.w3.org/TR/2008/REC-xml-20081126/#charsets">XML Ch. 2.2 - Characters</a>
+   * @param encodingPolicies Contains encoding rules defined at the time of building policy (if any). If no rules are
+   *                         configured or if this value is null, default behaviour (defined as Encoding.REPLACEMENT) is used
    */
   @TCB
   private static void encodeHtmlOnto(
-      String plainText, Appendable output, @Nullable String braceReplacement)
+      String plainText, Appendable output, @Nullable String braceReplacement, Map<Character, String> encodingPolicies)
           throws IOException {
     int n = plainText.length();
     int pos = 0;
@@ -194,6 +216,10 @@ final class Encoding {
       char ch = plainText.charAt(i);
       if (ch < REPLACEMENTS.length) {  // Handles all ASCII.
         String repl = REPLACEMENTS[ch];
+
+        if(encodingPolicies != null && encodingPolicies.containsKey(ch))
+          repl = encodingPolicies.get(ch);
+
         if (ch == '{' && repl == null) {
           if (i + 1 == n || plainText.charAt(i + 1) == '{') {
             repl = braceReplacement;

--- a/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
+++ b/src/main/java/org/owasp/html/HtmlPolicyBuilder.java
@@ -30,6 +30,7 @@ package org.owasp.html;
 
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -202,6 +203,14 @@ public class HtmlPolicyBuilder {
       AttributePolicy.REJECT_ALL_ATTRIBUTE_POLICY;
   private Set<String> extraRelsForLinks;
   private Set<String> skipRelsForLinks;
+  private Map<Character, String> encodingPolicies;
+
+  /*
+   * if any entry for encodingPolicies is null, the default behaviour as per Encoding.REPLACEMENT is used
+   */
+  public HtmlPolicyBuilder(){
+    encodingPolicies = new HashMap<Character, String>();
+  }
 
   /**
    * Allows the named elements.
@@ -393,6 +402,29 @@ public class HtmlPolicyBuilder {
             attributeName,
             AttributePolicy.Util.join(oldPolicy, policy));
       }
+    }
+    return this;
+  }
+
+  /*
+   * Call this function while building Policy before build() or toFactory() to disable encoding for all special characters
+   * Default behavior is encoding of all special characters as per Encoding.REPLACEMENT array
+   */
+  public HtmlPolicyBuilder disableEncoding(){
+    for(int i = 0; i < Encoding.REPLACEMENTS.length; i++) {
+      encodingPolicies.put((char) ('\0' + i),String.valueOf((char) ('\0' + i)));
+    }
+    return this;
+  }
+
+  /*
+   * Call this function while building Policy before build() or toFactory() to disable encoding for selected special character(s)
+   * Pass any number of Character arguments to disable encoding for that character.
+   */
+  public HtmlPolicyBuilder disableEncodingFor(Character... characterList){
+    for(Character entry : characterList){
+      if(entry < Encoding.REPLACEMENTS.length)
+        encodingPolicies.put(entry,String.valueOf(entry));
     }
     return this;
   }
@@ -643,7 +675,7 @@ public class HtmlPolicyBuilder {
     return new PolicyFactory(
         compiled.compiledPolicies, textContainerSet.build(),
         ImmutableMap.copyOf(compiled.globalAttrPolicies),
-        preprocessor, postprocessor);
+        preprocessor, postprocessor, encodingPolicies);
   }
 
   // Speed up subsequent builds by caching the compiled policies.

--- a/src/main/java/org/owasp/html/HtmlStreamRenderer.java
+++ b/src/main/java/org/owasp/html/HtmlStreamRenderer.java
@@ -34,6 +34,7 @@ import java.io.Flushable;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.WillCloseWhenClosed;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -57,12 +58,14 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
   private StringBuilder pendingUnescaped;
   private HtmlTextEscapingMode escapingMode = HtmlTextEscapingMode.PCDATA;
   private boolean open;
+  private Map<Character, String> encodingPolicies;
 
   /**
    * Factory.
    * @param output the buffer to which HTML is streamed.
    * @param ioExHandler called with any exception raised by output.
    * @param badHtmlHandler receives alerts when HTML cannot be rendered because
+   * @param encodingPolicies encoding rules defined at the time of Policy creation
    *    there is not valid HTML tree that results from that series of calls.
    *    E.g. it is not possible to create an HTML {@code <style>} element whose
    *    textual content is {@code "</style>"}.
@@ -70,16 +73,30 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
   public static HtmlStreamRenderer create(
       @WillCloseWhenClosed Appendable output,
       Handler<? super IOException> ioExHandler,
-      Handler<? super String> badHtmlHandler) {
+      Handler<? super String> badHtmlHandler,
+      Map<Character, String> encodingPolicies) {
+    HtmlStreamRenderer renderer;
     if (output instanceof Closeable) {
-      return new CloseableHtmlStreamRenderer(
+      renderer = new CloseableHtmlStreamRenderer(
           output, ioExHandler, badHtmlHandler);
     } else if (AutoCloseableHtmlStreamRenderer.isAutoCloseable(output)) {
-      return AutoCloseableHtmlStreamRenderer.createAutoCloseableHtmlStreamRenderer(
+      renderer = AutoCloseableHtmlStreamRenderer.createAutoCloseableHtmlStreamRenderer(
           output, ioExHandler, badHtmlHandler);
     } else {
-      return new HtmlStreamRenderer(output, ioExHandler, badHtmlHandler);
+      renderer = new HtmlStreamRenderer(output, ioExHandler, badHtmlHandler);
     }
+
+    if(renderer != null){
+      renderer.encodingPolicies = encodingPolicies;
+    }
+    return renderer;
+  }
+
+  public static HtmlStreamRenderer create(
+      @WillCloseWhenClosed Appendable output,
+      Handler<? super IOException> ioExHandler,
+      Handler<? super String> badHtmlHandler){
+    return create(output, ioExHandler, badHtmlHandler, null);
   }
 
   /**
@@ -93,7 +110,13 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
   public static HtmlStreamRenderer create(
       StringBuilder output, Handler<? super String> badHtmlHandler) {
     // Propagate since StringBuilder should not throw IOExceptions.
-    return create(output, Handler.PROPAGATE, badHtmlHandler);
+    return create(output, Handler.PROPAGATE, badHtmlHandler, null);
+  }
+
+  public static HtmlStreamRenderer create(
+      StringBuilder output, Handler<? super String> badHtmlHandler, Map<Character, String> encodingPolicies) {
+    // Propagate since StringBuilder should not throw IOExceptions.
+    return create(output, Handler.PROPAGATE, badHtmlHandler, encodingPolicies);
   }
 
   protected HtmlStreamRenderer(
@@ -193,7 +216,7 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
         continue;
       }
       output.append(' ').append(name).append('=').append('"');
-      Encoding.encodeHtmlAttribOnto(value, output);
+      Encoding.encodeHtmlAttribOnto(value, output, encodingPolicies);
       if (value.indexOf('`') != -1) {
         // Apparently, in quirks mode, IE8 does a poor job producing innerHTML
         // values.  Given
@@ -279,9 +302,9 @@ public class HtmlStreamRenderer implements HtmlStreamEventReceiver {
       pendingUnescaped.append(text);
     } else {
       if (this.escapingMode == HtmlTextEscapingMode.RCDATA) {
-        Encoding.encodeRcdataOnto(text, output);
+        Encoding.encodeRcdataOnto(text, output, encodingPolicies);
       } else {
-        Encoding.encodePcdataOnto(text, output);
+        Encoding.encodePcdataOnto(text, output, encodingPolicies);
       }
     }
   }

--- a/src/main/java/org/owasp/html/PolicyFactory.java
+++ b/src/main/java/org/owasp/html/PolicyFactory.java
@@ -34,6 +34,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.ThreadSafe;
+import javax.print.attribute.standard.Chromaticity;
 
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
@@ -58,18 +59,21 @@ public final class PolicyFactory
   private final ImmutableSet<String> textContainers;
   private final HtmlStreamEventProcessor preprocessor;
   private final HtmlStreamEventProcessor postprocessor;
+  private Map<Character, String> encodingPolicies;
 
   PolicyFactory(
       ImmutableMap<String, ElementAndAttributePolicies> policies,
       ImmutableSet<String> textContainers,
       ImmutableMap<String, AttributePolicy> globalAttrPolicies,
       HtmlStreamEventProcessor preprocessor,
-      HtmlStreamEventProcessor postprocessor) {
+      HtmlStreamEventProcessor postprocessor,
+      Map<Character, String> encodingPolicies) {
     this.policies = policies;
     this.textContainers = textContainers;
     this.globalAttrPolicies = globalAttrPolicies;
     this.preprocessor = preprocessor;
     this.postprocessor = postprocessor;
+    this.encodingPolicies = encodingPolicies;
   }
 
   /** Produces a sanitizer that emits tokens to {@code out}. */
@@ -127,7 +131,7 @@ public final class PolicyFactory
     HtmlSanitizer.sanitize(
         html,
         apply(
-            HtmlStreamRenderer.create(out, Handler.DO_NOTHING),
+            HtmlStreamRenderer.create(out, Handler.DO_NOTHING, encodingPolicies),
             listener,
             context),
         preprocessor);
@@ -210,6 +214,6 @@ public final class PolicyFactory
             this.postprocessor, f.postprocessor);
     return new PolicyFactory(
         b.build(), allTextContainers, allGlobalAttrPolicies,
-        compositionOfPreprocessors, compositionOfPostprocessors);
+        compositionOfPreprocessors, compositionOfPostprocessors, encodingPolicies);
   }
 }

--- a/src/test/java/org/owasp/html/SanitizersTest.java
+++ b/src/test/java/org/owasp/html/SanitizersTest.java
@@ -137,6 +137,54 @@ public class SanitizersTest extends TestCase {
         and2.sanitize(inputHtml));
   }
 
+  /*
+   * Test configurable policies to define encoding of special character(s)
+   * using disableEncoding() and disableEncodingFor()
+   */
+  @Test
+  public static final void testEncodingPolicies() {
+    /*
+     * Policy that follows default behaviour while encoding text found outside any tag
+     */
+    PolicyFactory s = new HtmlPolicyBuilder()
+        .toFactory();
+
+    assertEquals(
+        "foo&#64;bar&#43;foo&#61;bar", s.sanitize("foo@bar+foo=bar")
+    );
+    assertEquals(
+        "foo!bar&gt;foo#bar", s.sanitize("foo!bar>foo#bar")
+    );
+
+    /*
+     * Policy that disable encoding for all special characters
+     */
+    s = new HtmlPolicyBuilder()
+        .disableEncoding()
+        .toFactory();
+
+    assertEquals(
+        "foo&#64;bar&#43;foo&#61;bar", s.sanitize("foo@bar+foo=bar")
+    );
+    assertEquals(
+        "foo!bar&gt;foo#bar", s.sanitize("foo!bar>foo#bar")
+    );
+
+    /*
+     * Policy that disable encoding selected characters
+     */
+    s = new HtmlPolicyBuilder()
+        .disableEncodingFor('@','+')
+        .toFactory();
+
+    assertEquals(
+        "foo&#64;bar&#43;foo&#61;bar", s.sanitize("foo@bar+foo=bar")
+    );
+    assertEquals(
+        "foo!bar&gt;foo#bar", s.sanitize("foo!bar>foo#bar")
+    );
+  }
+
   @Test
   public static final void testImages() {
     PolicyFactory s = Sanitizers.IMAGES;


### PR DESCRIPTION
Added a <Character,String> Map to store custom text encoding policies, to override default behaviour. If custom policies are not created while building Policy, then the default behaviour is used.
This entity (encodingPolicies) is added as a member in HTMLPolicyBuilder and HTMLStreamRenderer. Required functions are overloaded to pass encodingPolicies as null if that parameter is missing. (For eg: when these functions are called without PolicyBuilder, as some of them are static functions)
null encodingPolicies results in default encoding behaviour.