### PR TITLE
Added encodingPolicies Map to make text encoding configurable

### DIFF
--- a/src/main/java/org/owasp/html/PolicyFactory.java
+++ b/src/main/java/org/owasp/html/PolicyFactory.java
@@ -58,18 +58,21 @@ public final class PolicyFactory
   private final ImmutableSet<String> textContainers;
   private final HtmlStreamEventProcessor preprocessor;
   private final HtmlStreamEventProcessor postprocessor;
+  private Map<Character, String> encodingPolicies;
 
   PolicyFactory(
       ImmutableMap<String, ElementAndAttributePolicies> policies,
       ImmutableSet<String> textContainers,
       ImmutableMap<String, AttributePolicy> globalAttrPolicies,
       HtmlStreamEventProcessor preprocessor,
-      HtmlStreamEventProcessor postprocessor) {
+      HtmlStreamEventProcessor postprocessor,
+      Map<Character, String> encodingPolicies) {
     this.policies = policies;
     this.textContainers = textContainers;
     this.globalAttrPolicies = globalAttrPolicies;
     this.preprocessor = preprocessor;
     this.postprocessor = postprocessor;
+    this.encodingPolicies = encodingPolicies;
   }
 
   /** Produces a sanitizer that emits tokens to {@code out}. */
@@ -127,7 +130,7 @@ public final class PolicyFactory
     HtmlSanitizer.sanitize(
         html,
         apply(
-            HtmlStreamRenderer.create(out, Handler.DO_NOTHING),
+            HtmlStreamRenderer.create(out, Handler.DO_NOTHING, encodingPolicies),
             listener,
             context),
         preprocessor);
@@ -210,6 +213,6 @@ public final class PolicyFactory
             this.postprocessor, f.postprocessor);
     return new PolicyFactory(
         b.build(), allTextContainers, allGlobalAttrPolicies,
-        compositionOfPreprocessors, compositionOfPostprocessors);
+        compositionOfPreprocessors, compositionOfPostprocessors, encodingPolicies);
   }
 }

--- a/src/test/java/org/owasp/html/SanitizersTest.java
+++ b/src/test/java/org/owasp/html/SanitizersTest.java
@@ -137,6 +137,55 @@ public class SanitizersTest extends TestCase {
         and2.sanitize(inputHtml));
   }
 
+  /*
+   * Test configurable policies to define encoding of special character(s)
+   * using disableEncoding() and disableEncodingFor()
+   */
+  @Test
+  public static final void testEncodingPolicies() {
+    /*
+     * Policy that follows default behaviour while encoding text found outside any tag
+     */
+    PolicyFactory s = new HtmlPolicyBuilder()
+        .toFactory();
+
+    assertEquals(
+        "foo&#64;bar&#43;foo&#61;bar", s.sanitize("foo@bar+foo=bar")
+    );
+
+    assertEquals(
+        "foo!bar&gt;foo#bar", s.sanitize("foo!bar>foo#bar")
+    );
+
+    /*
+     * Policy that disable encoding for all special characters
+     */
+    s = new HtmlPolicyBuilder()
+        .disableEncoding()
+        .toFactory();
+
+    assertEquals(
+        "foo@bar+foo=bar", s.sanitize("foo@bar+foo=bar")
+    );
+    assertEquals(
+        "foo!bar>foo#bar", s.sanitize("foo!bar>foo#bar")
+    );
+
+    /*
+     * Policy that disable encoding selected characters
+     */
+    s = new HtmlPolicyBuilder()
+        .disableEncodingFor('@', '+')
+        .toFactory();
+
+    assertEquals(
+        "foo@bar+foo&#61;bar", s.sanitize("foo@bar+foo=bar")
+    );
+    assertEquals(
+        "foo!bar&gt;foo@bar", s.sanitize("foo!bar>foo@bar")
+    );
+  }
+
   @Test
   public static final void testImages() {
     PolicyFactory s = Sanitizers.IMAGES;


### PR DESCRIPTION
Added a <Character,String> Map to store custom text encoding policies, to override default behaviour. If custom policies are not created while building Policy, then the default behaviour is used.
This entity (encodingPolicies) is added as a member in HTMLPolicyBuilder and HTMLStreamRenderer. Required functions are overloaded to pass encodingPolicies as null if that parameter is missing. (For eg: when these functions are called without PolicyBuilder, as some of them are static functions)
null encodingPolicies results in default encoding behaviour.